### PR TITLE
fix -mcversion argument in cli help menu

### DIFF
--- a/src/main/java/net/fabricmc/installer/client/ClientHandler.java
+++ b/src/main/java/net/fabricmc/installer/client/ClientHandler.java
@@ -75,7 +75,7 @@ public class ClientHandler extends Handler {
 
 	@Override
 	public String cliHelp() {
-		return "-dir <install dir, required> -version <minecraft version, default latest> -loader <loader version, default latest>";
+		return "-dir <install dir, required> -mcversion <minecraft version, default latest> -loader <loader version, default latest>";
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/installer/server/ServerHandler.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerHandler.java
@@ -70,7 +70,7 @@ public class ServerHandler extends Handler {
 
 	@Override
 	public String cliHelp() {
-		return "-dir <install dir, default current dir> -version <minecraft version, default latest> -loader <loader version, default latest> -downloadMinecraft";
+		return "-dir <install dir, default current dir> -mcversion <minecraft version, default latest> -loader <loader version, default latest> -downloadMinecraft";
 	}
 
 	@Override


### PR DESCRIPTION
Currently, the help menu suggests using -version <minecraft version> to install Fabric for a specific Minecraft version, the installer, however, is looking for -mcversion.