### PR TITLE
Write server JAR to a temporary file first

### DIFF
--- a/src/main/java/net/fabricmc/installer/server/ServerHandler.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerHandler.java
@@ -27,6 +27,8 @@ import javax.swing.*;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 public class ServerHandler extends Handler {
 
@@ -62,8 +64,11 @@ public class ServerHandler extends Handler {
 
 		if(args.has("downloadMinecraft")){
 			File serverJar = new File(file, "server.jar");
+			File serverJarTmp = new File(file, "server.jar.tmp");
+			Files.deleteIfExists(serverJar.toPath());
 			InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.download.minecraft"));
-			Utils.downloadFile(new URL(LauncherMeta.getLauncherMeta().getVersion(gameVersion).getVersionMeta().downloads.get("server").url), serverJar);
+			Utils.downloadFile(new URL(LauncherMeta.getLauncherMeta().getVersion(gameVersion).getVersionMeta().downloads.get("server").url), serverJarTmp);
+			Files.move(serverJarTmp.toPath(), serverJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
 			InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.done"));
 		}
 	}


### PR DESCRIPTION
Currently, if the downloading of the server JAR is interrupted, the user is left with a corrupt server.jar that Fabric loader will throw cryptic (or misleading) errors on, such as the following:

```
Exception in thread "main" java.lang.RuntimeException: Failed to setup Fabric server environment!
        at net.fabricmc.loader.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:51)
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: An exception occurred when launching the server!
        at net.fabricmc.loader.launch.server.FabricServerLauncher.setup(FabricServerLauncher.java:107)
        at net.fabricmc.loader.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:49)
Caused by: java.lang.RuntimeException: An exception occurred when launching the server!
        at net.fabricmc.loader.launch.server.FabricServerLauncher.launch(FabricServerLauncher.java:63)
        at net.fabricmc.loader.launch.server.FabricServerLauncher.setup(FabricServerLauncher.java:105)
        ... 1 more
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at net.fabricmc.loader.launch.server.FabricServerLauncher.launch(FabricServerLauncher.java:61)
        ... 2 more
Caused by: java.lang.NoClassDefFoundError: org/apache/logging/log4j/LogManager
        at net.fabricmc.loader.launch.common.FabricLauncherBase.<clinit>(FabricLauncherBase.java:44)
        at net.fabricmc.loader.launch.knot.KnotServer.main(KnotServer.java:26)
        ... 7 more
Caused by: java.lang.ClassNotFoundException: org.apache.logging.log4j.LogManager
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at net.fabricmc.loader.launch.server.InjectingURLClassLoader.loadClass(InjectingURLClassLoader.java:56)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        ... 9 more
```

 (I'm thinking of making a PR to Fabric loader to improve this error message - maybe do `Class.forName("org.apache.logging.log4j.LogManager")` with a try/catch in FabricServerLauncher.setup?)

This PR saves the server JAR to `server.jar.tmp` first, so that if the download is interrupted, Fabric loader won't try to use it. Once the download is complete, it gets renamed (or moved if renaming is not possible) to `server.jar`. It might also be a good idea to verify the hash of this file using the sha1 hash in the launcher metadata.