### PR TITLE
Move server library cache to target directory

### DIFF
--- a/src/main/java/net/fabricmc/installer/client/ClientHandler.java
+++ b/src/main/java/net/fabricmc/installer/client/ClientHandler.java
@@ -16,21 +16,26 @@
 
 package net.fabricmc.installer.client;
 
+import java.awt.Desktop;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+
+import javax.swing.JCheckBox;
+import javax.swing.JEditorPane;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.HyperlinkEvent;
+
 import net.fabricmc.installer.Handler;
 import net.fabricmc.installer.InstallerGui;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
 import net.fabricmc.installer.util.Reference;
 import net.fabricmc.installer.util.Utils;
-
-import javax.swing.*;
-import javax.swing.event.HyperlinkEvent;
-import java.awt.*;
-import java.io.FileNotFoundException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.MessageFormat;
 
 public class ClientHandler extends Handler {
 
@@ -86,7 +91,7 @@ public class ClientHandler extends Handler {
 
 	@Override
 	public void installCli(ArgumentParser args) throws Exception {
-		Path path = Paths.get(args.getOrDefault("dir", () -> Utils.findDefaultInstallDir().getAbsolutePath()));
+		Path path = Paths.get(args.getOrDefault("dir", () -> Utils.findDefaultInstallDir().toString()));
 		if (!Files.exists(path)) {
 			throw new FileNotFoundException("Launcher directory not found at " + path.toString());
 		}
@@ -115,7 +120,7 @@ public class ClientHandler extends Handler {
 	public void setupPane2(JPanel pane, InstallerGui installerGui) {
 		addRow(pane, jPanel -> jPanel.add(createProfile = new JCheckBox(Utils.BUNDLE.getString("option.create.profile"), true)));
 
-		installLocation.setText(Utils.findDefaultInstallDir().getAbsolutePath());
+		installLocation.setText(Utils.findDefaultInstallDir().toString());
 	}
 
 }

--- a/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
@@ -16,14 +16,8 @@
 
 package net.fabricmc.installer.server;
 
-import mjson.Json;
-import net.fabricmc.installer.util.*;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,8 +25,17 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
@@ -40,56 +43,52 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import mjson.Json;
+
+import net.fabricmc.installer.util.InstallerProgress;
+import net.fabricmc.installer.util.Library;
+import net.fabricmc.installer.util.Reference;
+import net.fabricmc.installer.util.Utils;
+
 public class ServerInstaller {
 	private static final String servicesDir = "META-INF/services/";
 
-	public static void install(File dir, String loaderVersion, String gameVersion, InstallerProgress progress) throws IOException {
+	public static void install(Path dir, String loaderVersion, String gameVersion, InstallerProgress progress) throws IOException {
 		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.installing.server")).format(new Object[]{String.format("%s(%s)", loaderVersion, gameVersion)}));
-		File libsDir = new File(Utils.findDefaultUserDir(), ".cache" + File.separator + "fabric-installer" + File.separator + "libraries");
-		if (!libsDir.exists()) {
-			if (!libsDir.mkdirs()) {
-				throw new IOException("Could not create " + libsDir.getAbsolutePath() + "!");
-			}
-		}
-		if(!dir.exists()){
-			if (!dir.mkdirs()) {
-				throw new IOException("Could not create " + dir.getAbsolutePath() + "!");
-			}
-		}
+		Path libsDir = Utils.findDefaultUserDir().resolve(".cache").resolve("fabric-installer").resolve("libraries");
+
+		Files.createDirectories(libsDir);
+		Files.createDirectories(dir);
 
 		progress.updateProgress(Utils.BUNDLE.getString("progress.download.libraries"));
 
 		URL profileUrl = new URL(Reference.getMetaServerEndpoint(String.format("v2/versions/loader/%s/%s/server/json", gameVersion, loaderVersion)));
 		Json json = Json.read(Utils.readTextFile(profileUrl));
 
-		List<File> libraryFiles = new ArrayList<>();
+		List<Path> libraryFiles = new ArrayList<>();
 
 		for (Json libraryJson : json.at("libraries").asJsonList()) {
 			Library library = new Library(libraryJson);
 
 			progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.download.library.entry")).format(new Object[]{library.name}));
-			File libraryFile = new File(libsDir, library.getFileName());
-			Utils.downloadFile(new URL(library.getURL()), libraryFile.toPath());
+			Path libraryFile = libsDir.resolve(library.getFileName());
+			Utils.downloadFile(new URL(library.getURL()), libraryFile);
 			libraryFiles.add(libraryFile);
 		}
 
 		progress.updateProgress(Utils.BUNDLE.getString("progress.generating.launch.jar"));
 
-		File launchJar = new File(dir, "fabric-server-launch.jar");
+		Path launchJar = dir.resolve("fabric-server-launch.jar");
 		String mainClass = json.at("mainClass").asString();
 		makeLaunchJar(launchJar, mainClass, libraryFiles, progress);
 
-		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.done.start.server")).format(new Object[]{launchJar.getName()}));
+		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.done.start.server")).format(new Object[]{launchJar.getFileName().toString()}));
 	}
 
-	private static void makeLaunchJar(File file, String mainclass, List<File> libraryFiles, InstallerProgress progress) throws IOException {
-		if (file.exists()) {
-			if (!file.delete()) {
-				throw new IOException("Could not delete file: " + file.getAbsolutePath());
-			}
-		}
+	private static void makeLaunchJar(Path file, String mainclass, List<Path> libraryFiles, InstallerProgress progress) throws IOException {
+		Files.deleteIfExists(file);
 
-		FileOutputStream outputStream = new FileOutputStream(file);
+		OutputStream outputStream = Files.newOutputStream(file);
 		ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
 
 		Set<String> addedEntries = new HashSet<>();
@@ -113,14 +112,12 @@ public class ServerInstaller {
 			Map<String, Set<String>> services = new HashMap<>();
 			byte[] buffer = new byte[32768];
 
-			for (File f : libraryFiles) {
-				progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.generating.launch.jar.library")).format(new Object[]{f.getName()}));
+			for (Path f : libraryFiles) {
+				progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.generating.launch.jar.library")).format(new Object[]{f.getFileName().toString()}));
 
 				// read service definitions (merging them), copy other files
-				try (
-						FileInputStream is = new FileInputStream(f);
-						JarInputStream jis = new JarInputStream(is)
-				) {
+				try (InputStream is = Files.newInputStream(f);
+						JarInputStream jis = new JarInputStream(is)) {
 					JarEntry entry;
 					while ((entry = jis.getNextJarEntry()) != null) {
 						if (entry.isDirectory()) continue;

--- a/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
@@ -55,10 +55,11 @@ public class ServerInstaller {
 
 	public static void install(Path dir, String loaderVersion, String gameVersion, InstallerProgress progress) throws IOException {
 		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.installing.server")).format(new Object[]{String.format("%s(%s)", loaderVersion, gameVersion)}));
-		Path libsDir = Utils.findDefaultUserDir().resolve(".cache").resolve("fabric-installer").resolve("libraries");
 
-		Files.createDirectories(libsDir);
 		Files.createDirectories(dir);
+
+		Path libsDir = dir.resolve(".fabric-installer").resolve("libraries");
+		Files.createDirectories(libsDir);
 
 		progress.updateProgress(Utils.BUNDLE.getString("progress.download.libraries"));
 

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -16,10 +16,7 @@
 
 package net.fabricmc.installer.util;
 
-import mjson.Json;
-
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -28,6 +25,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -57,36 +55,34 @@ public class Utils {
 		}
 	});
 
-	public static File findDefaultUserDir() {
+	public static Path findDefaultUserDir() {
 		String home = System.getProperty("user.home", ".");
-		String os = System.getProperty("os.name").toLowerCase();
-		File dir;
-		File homeDir = new File(home);
+		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		Path dir;
 
 		if (os.contains("win") && System.getenv("APPDATA") != null) {
-			dir = new File(System.getenv("APPDATA"));
-		} else if (os.contains("mac")) {
-			dir = new File(homeDir, "Library" + File.separator + "Application Support");
+			dir = Paths.get(System.getenv("APPDATA")).toAbsolutePath().normalize();
 		} else {
-			dir = homeDir;
+			Path homeDir = Paths.get(home).toAbsolutePath().normalize();
+
+			if (os.contains("mac")) {
+				dir = homeDir.resolve("Library").resolve("Application Support");
+			} else {
+				dir = homeDir;
+			}
 		}
+
 		return dir;
 	}
 
-	public static File findDefaultInstallDir() {
-		String home = System.getProperty("user.home", ".");
-		String os = System.getProperty("os.name").toLowerCase();
-		File dir;
-		File homeDir = new File(home);
+	public static Path findDefaultInstallDir() {
+		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 
-		if (os.contains("win") && System.getenv("APPDATA") != null) {
-			dir = new File(System.getenv("APPDATA"), ".minecraft");
-		} else if (os.contains("mac")) {
-			dir = new File(homeDir, "Library" + File.separator + "Application Support" + File.separator + "minecraft");
+		if (os.contains("mac")) {
+			return findDefaultUserDir().resolve("minecraft");
 		} else {
-			dir = new File(homeDir, ".minecraft");
+			return findDefaultUserDir().resolve(".minecraft");
 		}
-		return dir;
 	}
 
 	public static Reader urlReader(URL url) throws IOException {

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -55,34 +55,24 @@ public class Utils {
 		}
 	});
 
-	public static Path findDefaultUserDir() {
-		String home = System.getProperty("user.home", ".");
+	public static Path findDefaultInstallDir() {
 		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 		Path dir;
 
 		if (os.contains("win") && System.getenv("APPDATA") != null) {
-			dir = Paths.get(System.getenv("APPDATA")).toAbsolutePath().normalize();
+			dir = Paths.get(System.getenv("APPDATA")).resolve(".minecraft");
 		} else {
-			Path homeDir = Paths.get(home).toAbsolutePath().normalize();
+			String home = System.getProperty("user.home", ".");
+			Path homeDir = Paths.get(home);
 
 			if (os.contains("mac")) {
-				dir = homeDir.resolve("Library").resolve("Application Support");
+				dir = homeDir.resolve("Library").resolve("Application Support").resolve("minecraft");
 			} else {
-				dir = homeDir;
+				dir = homeDir.resolve(".minecraft");
 			}
 		}
 
-		return dir;
-	}
-
-	public static Path findDefaultInstallDir() {
-		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-
-		if (os.contains("mac")) {
-			return findDefaultUserDir().resolve("minecraft");
-		} else {
-			return findDefaultUserDir().resolve(".minecraft");
-		}
+		return dir.toAbsolutePath().normalize();
 	}
 
 	public static Reader urlReader(URL url) throws IOException {


### PR DESCRIPTION
This should fix https://github.com/FabricMC/fabric-installer/issues/64 and potentially some permission issues - not really worth polluting the home dir for a few MB.

The PR comes in 2 commits, the first migrates more aspects to Path and does a little cleanup, the 2nd implements the directory change.