### PR TITLE
Unattended server installer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.gradle]
+indent_style = tab
+
+[*.java]
+indent_style = tab
+ij_continuation_indent_size = 8
+ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.fabricmc.**
+ij_java_class_count_to_use_import_on_demand = 999

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 !/LICENSE
 !/README.md
 !/settings.gradle
+!/.editorconfig

--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,32 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 shadowJar {
+	manifest {
+		attributes 'Implementation-Title': 'FabricInstaller',
+				'Implementation-Version': project.version,
+				'Main-Class': 'net.fabricmc.installer.Main'
+	}
+
 	minimize()
 	archiveClassifier.set(null)
 	exclude('icon.ico')
 }
+
+task unattendedJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+	manifest {
+		attributes 'Implementation-Title': 'FabricInstaller',
+				'Implementation-Version': project.version,
+				'Main-Class': 'net.fabricmc.installer.UnattendedMain'
+	}
+
+	minimize()
+	exclude('icon.ico')
+
+	archiveClassifier = "unattended"
+	from sourceSets.main.output
+	configurations = [project.configurations.compileClasspath]
+}
+assemble.dependsOn unattendedJar
 
 def bootstrapVersion = "0.1.3"
 def bootstrapArch = "i686"
@@ -69,11 +91,6 @@ task nativeExe(dependsOn: [shadowJar, downloadBootstrap], type: FileOutput) {
 build.dependsOn nativeExe
 
 jar {
-    manifest {
-        attributes 'Implementation-Title': 'FabricInstaller',
-                'Implementation-Version': project.version,
-                'Main-Class': 'net.fabricmc.installer.Main'
-    }
 	enabled = false
 }
 
@@ -116,6 +133,11 @@ publishing {
 			}
 
 			artifact nativeExe.output
+
+			// No point in signing as it is designed to get modified
+			artifact (unattendedJar) {
+				classifier "unattended"
+			}
 		}
 	}
 	repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -45,21 +45,21 @@ shadowJar {
 	exclude('icon.ico')
 }
 
-task unattendedJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+task serverJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
 	manifest {
 		attributes 'Implementation-Title': 'FabricInstaller',
 				'Implementation-Version': project.version,
-				'Main-Class': 'net.fabricmc.installer.UnattendedMain'
+				'Main-Class': 'net.fabricmc.installer.ServerLauncher'
 	}
 
 	minimize()
 	exclude('icon.ico')
 
-	archiveClassifier = "unattended"
+	archiveClassifier = "server"
 	from sourceSets.main.output
 	configurations = [project.configurations.compileClasspath]
 }
-assemble.dependsOn unattendedJar
+assemble.dependsOn serverJar
 
 def bootstrapVersion = "0.1.3"
 def bootstrapArch = "i686"
@@ -135,8 +135,8 @@ publishing {
 			artifact nativeExe.output
 
 			// No point in signing as it is designed to get modified
-			artifact (unattendedJar) {
-				classifier "unattended"
+			artifact (serverJar) {
+				classifier "server"
 			}
 		}
 	}

--- a/src/main/java/net/fabricmc/installer/ServerLauncher.java
+++ b/src/main/java/net/fabricmc/installer/ServerLauncher.java
@@ -16,11 +16,6 @@
 
 package net.fabricmc.installer;
 
-import net.fabricmc.installer.server.MinecraftServerDownloader;
-import net.fabricmc.installer.server.ServerInstaller;
-import net.fabricmc.installer.util.InstallerProgress;
-import net.fabricmc.installer.util.Utils;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandle;
@@ -38,129 +33,134 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipError;
 
+import net.fabricmc.installer.server.MinecraftServerDownloader;
+import net.fabricmc.installer.server.ServerInstaller;
+import net.fabricmc.installer.util.InstallerProgress;
+import net.fabricmc.installer.util.Utils;
+
 public final class ServerLauncher {
-    private static final String INSTALL_CONFIG_NAME = "install.properties";
-    private static final Path SERVER_DIR = Paths.get(".fabric", "server").toAbsolutePath();
+	private static final String INSTALL_CONFIG_NAME = "install.properties";
+	private static final Path SERVER_DIR = Paths.get(".fabric", "server").toAbsolutePath();
 
-    public static void main(String[] args) throws Throwable {
-        LaunchData launchData;
-        try {
-            launchData = initialise();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to setup fabric server", e);
-        }
+	public static void main(String[] args) throws Throwable {
+		LaunchData launchData;
+		try {
+			launchData = initialise();
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to setup fabric server", e);
+		}
 
-        Objects.requireNonNull(launchData, "launchData is null, cannot proceed");
+		Objects.requireNonNull(launchData, "launchData is null, cannot proceed");
 
-        // Set the game jar path to bypass loader's own lookup
-        System.setProperty("fabric.gameJarPath", launchData.serverJar.toAbsolutePath().toString());
+		// Set the game jar path to bypass loader's own lookup
+		System.setProperty("fabric.gameJarPath", launchData.serverJar.toAbsolutePath().toString());
 
-        URLClassLoader launchClassLoader = new URLClassLoader(new URL[]{ launchData.launchJar.toUri().toURL() });
+		URLClassLoader launchClassLoader = new URLClassLoader(new URL[]{launchData.launchJar.toUri().toURL()});
 
-        // Use method handle to keep the stacktrace clean
-        MethodHandle handle = MethodHandles.publicLookup().findStatic(launchClassLoader.loadClass(launchData.mainClass), "main", MethodType.methodType(void.class, String[].class));
-        handle.invokeExact(args);
-    }
+		// Use method handle to keep the stacktrace clean
+		MethodHandle handle = MethodHandles.publicLookup().findStatic(launchClassLoader.loadClass(launchData.mainClass), "main", MethodType.methodType(void.class, String[].class));
+		handle.invokeExact(args);
+	}
 
-    // Validates and downloads/installs the server if required
-    private static LaunchData initialise() throws IOException {
-        Properties properties = readProperties();
+	// Validates and downloads/installs the server if required
+	private static LaunchData initialise() throws IOException {
+		Properties properties = readProperties();
 
-        String loaderVersion = Objects.requireNonNull(properties.getProperty("fabric-loader-version"), "no loader-version specified in " + INSTALL_CONFIG_NAME);
-        String gameVersion = Objects.requireNonNull(properties.getProperty("game-version"), "no game-version specified in " + INSTALL_CONFIG_NAME);
+		String loaderVersion = Objects.requireNonNull(properties.getProperty("fabric-loader-version"), "no loader-version specified in " + INSTALL_CONFIG_NAME);
+		String gameVersion = Objects.requireNonNull(properties.getProperty("game-version"), "no game-version specified in " + INSTALL_CONFIG_NAME);
 
-        // 0.12 or higher is required
-        validateLoaderVersion(loaderVersion);
+		// 0.12 or higher is required
+		validateLoaderVersion(loaderVersion);
 
-        // Vanilla server jar
-        Path serverJar = SERVER_DIR.resolve(String.format("%s-server.jar", gameVersion));
-        // Includes the mc version as this jar contains intermediary
-        Path serverLaunchJar = SERVER_DIR.resolve(String.format("fabric-loader-server-%s-minecraft-%s.jar", loaderVersion, gameVersion));
+		// Vanilla server jar
+		Path serverJar = SERVER_DIR.resolve(String.format("%s-server.jar", gameVersion));
+		// Includes the mc version as this jar contains intermediary
+		Path serverLaunchJar = SERVER_DIR.resolve(String.format("fabric-loader-server-%s-minecraft-%s.jar", loaderVersion, gameVersion));
 
-        if (Files.exists(serverJar) && Files.exists(serverLaunchJar)) {
-            try {
-                String mainClass = readMainClass(serverLaunchJar);
-                // All seems good, no need to reinstall
-                return new LaunchData(serverJar, serverLaunchJar, mainClass);
-            } catch (IOException | ZipError e) {
-                // Wont throw here, will try to reinstall
-                System.err.println("Failed to read main class from server launch jar: " + e.getMessage());
-            }
-        }
+		if (Files.exists(serverJar) && Files.exists(serverLaunchJar)) {
+			try {
+				String mainClass = readMainClass(serverLaunchJar);
+				// All seems good, no need to reinstall
+				return new LaunchData(serverJar, serverLaunchJar, mainClass);
+			} catch (IOException | ZipError e) {
+				// Wont throw here, will try to reinstall
+				System.err.println("Failed to read main class from server launch jar: " + e.getMessage());
+			}
+		}
 
-        Files.createDirectories(SERVER_DIR);
-        ServerInstaller.install(SERVER_DIR, loaderVersion, gameVersion, InstallerProgress.CONSOLE, serverLaunchJar);
+		Files.createDirectories(SERVER_DIR);
+		ServerInstaller.install(SERVER_DIR, loaderVersion, gameVersion, InstallerProgress.CONSOLE, serverLaunchJar);
 
-        InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.download.minecraft"));
-        MinecraftServerDownloader downloader = new MinecraftServerDownloader(gameVersion);
-        downloader.downloadMinecraftServer(serverJar);
+		InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.download.minecraft"));
+		MinecraftServerDownloader downloader = new MinecraftServerDownloader(gameVersion);
+		downloader.downloadMinecraftServer(serverJar);
 
-        String mainClass = readMainClass(serverLaunchJar);
+		String mainClass = readMainClass(serverLaunchJar);
 
-        return new LaunchData(serverJar, serverLaunchJar, mainClass);
-    }
+		return new LaunchData(serverJar, serverLaunchJar, mainClass);
+	}
 
-    private static Properties readProperties() throws IOException {
-        Properties properties = new Properties();
+	private static Properties readProperties() throws IOException {
+		Properties properties = new Properties();
 
-        URL config = getConfigFromResources();
+		URL config = getConfigFromResources();
 
-        if (config == null) {
-            throw new RuntimeException("Jar does not contain unattended install.properties file");
-        }
+		if (config == null) {
+			throw new RuntimeException("Jar does not contain unattended install.properties file");
+		}
 
-        try (InputStreamReader reader = new InputStreamReader(config.openStream(), StandardCharsets.UTF_8)) {
-            properties.load(reader);
-        } catch (IOException e) {
-            throw new IOException("Failed to read " + INSTALL_CONFIG_NAME, e);
-        }
+		try (InputStreamReader reader = new InputStreamReader(config.openStream(), StandardCharsets.UTF_8)) {
+			properties.load(reader);
+		} catch (IOException e) {
+			throw new IOException("Failed to read " + INSTALL_CONFIG_NAME, e);
+		}
 
-        return properties;
-    }
+		return properties;
+	}
 
-    // Find the mainclass of a jar file
-    private static String readMainClass(Path path) throws IOException {
-        try (JarFile jarFile = new JarFile(path.toFile())) {
-            Manifest manifest = jarFile.getManifest();
-            String mainClass = manifest.getMainAttributes().getValue("Main-Class");
+	// Find the mainclass of a jar file
+	private static String readMainClass(Path path) throws IOException {
+		try (JarFile jarFile = new JarFile(path.toFile())) {
+			Manifest manifest = jarFile.getManifest();
+			String mainClass = manifest.getMainAttributes().getValue("Main-Class");
 
-            if (mainClass == null) {
-                throw new IOException("Jar does not have a Main-Class attribute");
-            }
+			if (mainClass == null) {
+				throw new IOException("Jar does not have a Main-Class attribute");
+			}
 
-            return mainClass;
-        }
-    }
+			return mainClass;
+		}
+	}
 
-    private static void validateLoaderVersion(String loaderVersion) {
-        String[] versionSplit = loaderVersion.split("\\.");
+	private static void validateLoaderVersion(String loaderVersion) {
+		String[] versionSplit = loaderVersion.split("\\.");
 
-        // future 1.x versions
-        if (Integer.parseInt(versionSplit[0]) > 0) {
-            return;
-        }
+		// future 1.x versions
+		if (Integer.parseInt(versionSplit[0]) > 0) {
+			return;
+		}
 
-        // 0.12.x or newer
-        if (Integer.parseInt(versionSplit[1]) >= 12) {
-            return;
-        }
+		// 0.12.x or newer
+		if (Integer.parseInt(versionSplit[1]) >= 12) {
+			return;
+		}
 
-        throw new UnsupportedOperationException("Fabric loader 0.12 or higher is required for unattended server installs. Please use a newer fabric loader version, or the full installer.");
-    }
+		throw new UnsupportedOperationException("Fabric loader 0.12 or higher is required for unattended server installs. Please use a newer fabric loader version, or the full installer.");
+	}
 
-    private static URL getConfigFromResources() {
-        return ServerLauncher.class.getClassLoader().getResource(INSTALL_CONFIG_NAME);
-    }
+	private static URL getConfigFromResources() {
+		return ServerLauncher.class.getClassLoader().getResource(INSTALL_CONFIG_NAME);
+	}
 
-    private static class LaunchData {
-        final Path serverJar;
-        final Path launchJar;
-        final String mainClass;
+	private static class LaunchData {
+		final Path serverJar;
+		final Path launchJar;
+		final String mainClass;
 
-        public LaunchData(Path serverJar, Path launchJar, String mainClass) {
-            this.serverJar = Objects.requireNonNull(serverJar, "serverJar");
-            this.launchJar = Objects.requireNonNull(launchJar, "launchJar");
-            this.mainClass = Objects.requireNonNull(mainClass, "mainClass");
-        }
-    }
+		public LaunchData(Path serverJar, Path launchJar, String mainClass) {
+			this.serverJar = Objects.requireNonNull(serverJar, "serverJar");
+			this.launchJar = Objects.requireNonNull(launchJar, "launchJar");
+			this.mainClass = Objects.requireNonNull(mainClass, "mainClass");
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/installer/UnattendedMain.java
+++ b/src/main/java/net/fabricmc/installer/UnattendedMain.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.installer;
+
+import net.fabricmc.installer.server.MinecraftServerDownloader;
+import net.fabricmc.installer.server.ServerInstaller;
+import net.fabricmc.installer.util.InstallerProgress;
+import net.fabricmc.installer.util.Utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public final class UnattendedMain {
+    private static final String INSTALL_CONFIG_NAME = "install.properties";
+    private static final Path SERVER_DIR = Paths.get("", ".fabric", "server");
+
+    public static void main(String[] args) throws Throwable {
+        LaunchData launchData;
+        try {
+            launchData = initialise();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to setup fabric server", e);
+        }
+
+        Objects.requireNonNull(launchData, "launchData is null, cannot proceed");
+
+        // Set the game jar path to bypass loader's own lookup
+        System.setProperty("fabric.gameJarPath", launchData.serverJar.toAbsolutePath().toString());
+
+        URLClassLoader launchClassLoader = new URLClassLoader(new URL[]{ launchData.launchJar.toUri().toURL() });
+
+        // Use method handle to keep the stacktrace clean
+        MethodHandle handle = MethodHandles.publicLookup().findStatic(launchClassLoader.loadClass(launchData.mainClass), "main", MethodType.methodType(void.class, String[].class));
+        handle.invokeExact(args);
+    }
+
+    // Validates and downloads/installs the server if required
+    private static LaunchData initialise() throws IOException {
+        Properties properties = readProperties();
+
+        String loaderVersion = Objects.requireNonNull(properties.getProperty("fabric-loader-version"), "no loader-version specified in " + INSTALL_CONFIG_NAME);
+        String gameVersion = Objects.requireNonNull(properties.getProperty("game-version"), "no game-version specified in " + INSTALL_CONFIG_NAME);
+
+        // 0.12 or higher is required
+        validateLoaderVersion(loaderVersion);
+
+        // Vanilla server jar
+        Path serverJar = SERVER_DIR.resolve(String.format("%s-server.jar", gameVersion));
+        // Includes the mc version as this jar contains intermediary
+        Path serverLaunchJar = SERVER_DIR.resolve(String.format("fabric-loader-server-%s-minecraft-%s", loaderVersion, gameVersion));
+
+        String mainClass = null;
+
+        if (Files.exists(serverJar) && Files.exists(serverLaunchJar)) {
+            try {
+                mainClass = readMainClass(serverLaunchJar);
+            } catch (IOException e) {
+                // Wont throw here, will try to reinstall
+                System.err.println("Failed to read main class from server launch jar: " + e.getMessage());
+            }
+        }
+
+        if (mainClass != null) {
+            // All seems good, no need to reinstall
+            return new LaunchData(serverJar, serverLaunchJar, mainClass);
+        }
+
+        // TODO improve log output, its quite messy atm
+        Files.createDirectories(SERVER_DIR);
+        ServerInstaller.install(SERVER_DIR, loaderVersion, gameVersion, InstallerProgress.CONSOLE, serverLaunchJar);
+
+        InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.download.minecraft"));
+        MinecraftServerDownloader downloader = new MinecraftServerDownloader(gameVersion);
+        downloader.downloadMinecraftServer(serverJar);
+
+        mainClass = readMainClass(serverLaunchJar);
+
+        return new LaunchData(serverJar, serverLaunchJar, mainClass);
+    }
+
+    private static Properties readProperties() throws IOException {
+        Properties properties = new Properties();
+
+        URL config = getConfigFromResources();
+
+        if (config == null) {
+            throw new RuntimeException("Jar does not contain unattended install.properties file");
+        }
+
+        try (InputStream is = config.openStream()) {
+            properties.load(is);
+        } catch (IOException e) {
+            throw new IOException("Failed to read stamped installer data", e);
+        }
+
+        return properties;
+    }
+
+    // Find the mainclass of a jar file
+    private static String readMainClass(Path path) throws IOException {
+        try (ZipFile zipFile = new ZipFile(path.toFile())) {
+            ZipEntry zipEntry = zipFile.getEntry("META-INF/MANIFEST.MF");
+
+            if (zipEntry == null) {
+                throw new IOException("Failed to find manifest in jar");
+            }
+
+            try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
+                Manifest manifest = new Manifest(inputStream);
+                String mainClass = manifest.getMainAttributes().getValue("Main-Class");
+
+                if (mainClass == null) {
+                    throw new IOException("Jar does not have a Main-Class attribute");
+                }
+
+                return mainClass;
+            }
+        }
+    }
+
+    private static void validateLoaderVersion(String loaderVersion) {
+        int[] versionSplit = Arrays.stream(loaderVersion.split("\\."))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+
+        // future 1.x versions
+        if (versionSplit[0] > 0) {
+            return;
+        }
+
+        // 0.12.x or newer
+        if (versionSplit[1] > 12) {
+            return;
+        }
+
+        throw new UnsupportedOperationException("Fabric loader 0.12 or higher is required for unattended server installs. Please use a newer fabric loader version, or the full installer.");
+    }
+
+    private static URL getConfigFromResources() {
+        return UnattendedMain.class.getClassLoader().getResource(INSTALL_CONFIG_NAME);
+    }
+
+    private static class LaunchData {
+        final Path serverJar;
+        final Path launchJar;
+        final String mainClass;
+
+        public LaunchData(Path serverJar, Path launchJar, String mainClass) {
+            this.serverJar = Objects.requireNonNull(serverJar, "serverJar");
+            this.launchJar = Objects.requireNonNull(launchJar, "launchJar");
+            this.mainClass = Objects.requireNonNull(mainClass, "mainClass");
+        }
+    }
+}

--- a/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
+++ b/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
@@ -34,11 +34,28 @@ public class MinecraftServerDownloader {
 	}
 
 	public void downloadMinecraftServer(Path serverJar) throws IOException {
+		if (isServerJarValid(serverJar)) {
+			System.out.println("Existing server jar valid, not downloading");
+			return;
+		}
+
 		Path serverJarTmp = serverJar.resolveSibling(serverJar.getFileName().toString() + ".tmp");
 		Files.deleteIfExists(serverJar);
 		Utils.downloadFile(new URL(getServerDownload().url), serverJarTmp);
 
+		if (!isServerJarValid(serverJarTmp)) {
+			throw new IOException("Failed to validate downloaded server jar");
+		}
+
 		Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	private boolean isServerJarValid(Path serverJar) throws IOException {
+		if (!Files.exists(serverJar)) {
+			return false;
+		}
+
+		return Utils.sha1String(serverJar).equalsIgnoreCase(getServerDownload().sha1);
 	}
 
 	private VersionMeta getVersionMeta() throws IOException {

--- a/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
+++ b/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
@@ -16,42 +16,42 @@
 
 package net.fabricmc.installer.server;
 
-import net.fabricmc.installer.util.LauncherMeta;
-import net.fabricmc.installer.util.Utils;
-import net.fabricmc.installer.util.VersionMeta;
-
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
+import net.fabricmc.installer.util.LauncherMeta;
+import net.fabricmc.installer.util.Utils;
+import net.fabricmc.installer.util.VersionMeta;
+
 public class MinecraftServerDownloader {
-    private final String gameVersion;
+	private final String gameVersion;
 
-    public MinecraftServerDownloader(String gameVersion) {
-        this.gameVersion = gameVersion;
-    }
+	public MinecraftServerDownloader(String gameVersion) {
+		this.gameVersion = gameVersion;
+	}
 
-    public void downloadMinecraftServer(Path serverJar) throws IOException {
-        Path serverJarTmp = serverJar.resolveSibling(serverJar.getFileName().toString() + ".tmp");
-        Files.deleteIfExists(serverJar);
-        Utils.downloadFile(new URL(getServerDownload().url), serverJarTmp);
+	public void downloadMinecraftServer(Path serverJar) throws IOException {
+		Path serverJarTmp = serverJar.resolveSibling(serverJar.getFileName().toString() + ".tmp");
+		Files.deleteIfExists(serverJar);
+		Utils.downloadFile(new URL(getServerDownload().url), serverJarTmp);
 
-        Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
-    }
+		Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
+	}
 
-    private VersionMeta getVersionMeta() throws IOException {
-        LauncherMeta.Version version = LauncherMeta.getLauncherMeta().getVersion(gameVersion);
+	private VersionMeta getVersionMeta() throws IOException {
+		LauncherMeta.Version version = LauncherMeta.getLauncherMeta().getVersion(gameVersion);
 
-        if (version == null) {
-            throw new RuntimeException("Failed to find version info for minecraft " + gameVersion);
-        }
+		if (version == null) {
+			throw new RuntimeException("Failed to find version info for minecraft " + gameVersion);
+		}
 
-        return version.getVersionMeta();
-    }
+		return version.getVersionMeta();
+	}
 
-    private VersionMeta.Download getServerDownload() throws IOException {
-        return getVersionMeta().downloads.get("server");
-    }
+	private VersionMeta.Download getServerDownload() throws IOException {
+		return getVersionMeta().downloads.get("server");
+	}
 }

--- a/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
+++ b/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.installer.server;
+
+import net.fabricmc.installer.util.LauncherMeta;
+import net.fabricmc.installer.util.Utils;
+import net.fabricmc.installer.util.VersionMeta;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+public class MinecraftServerDownloader {
+    private final String gameVersion;
+
+    public MinecraftServerDownloader(String gameVersion) {
+        this.gameVersion = gameVersion;
+    }
+
+    public void downloadMinecraftServer(Path serverJar) throws IOException {
+        Path serverJarTmp = serverJar.getParent().resolve(serverJar.getFileName().toString() + ".tmp");
+        Files.deleteIfExists(serverJar);
+        Utils.downloadFile(new URL(getVersionMeta().downloads.get("server").url), serverJarTmp);
+
+        if (!validateServerHash(serverJarTmp)) {
+            throw new IOException("Failed to validate server jar hash");
+        }
+
+        Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public boolean validateServerHash(Path serverJar) {
+        if (!Files.exists(serverJar)) {
+            return false;
+        }
+
+        // TODO
+        return true;
+    }
+
+    // TODO support experimental versions
+    // TODO cache this
+    private VersionMeta getVersionMeta() throws IOException {
+        return LauncherMeta.getLauncherMeta().getVersion(gameVersion).getVersionMeta();
+    }
+}

--- a/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
+++ b/src/main/java/net/fabricmc/installer/server/MinecraftServerDownloader.java
@@ -34,29 +34,24 @@ public class MinecraftServerDownloader {
     }
 
     public void downloadMinecraftServer(Path serverJar) throws IOException {
-        Path serverJarTmp = serverJar.getParent().resolve(serverJar.getFileName().toString() + ".tmp");
+        Path serverJarTmp = serverJar.resolveSibling(serverJar.getFileName().toString() + ".tmp");
         Files.deleteIfExists(serverJar);
-        Utils.downloadFile(new URL(getVersionMeta().downloads.get("server").url), serverJarTmp);
-
-        if (!validateServerHash(serverJarTmp)) {
-            throw new IOException("Failed to validate server jar hash");
-        }
+        Utils.downloadFile(new URL(getServerDownload().url), serverJarTmp);
 
         Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
     }
 
-    public boolean validateServerHash(Path serverJar) {
-        if (!Files.exists(serverJar)) {
-            return false;
+    private VersionMeta getVersionMeta() throws IOException {
+        LauncherMeta.Version version = LauncherMeta.getLauncherMeta().getVersion(gameVersion);
+
+        if (version == null) {
+            throw new RuntimeException("Failed to find version info for minecraft " + gameVersion);
         }
 
-        // TODO
-        return true;
+        return version.getVersionMeta();
     }
 
-    // TODO support experimental versions
-    // TODO cache this
-    private VersionMeta getVersionMeta() throws IOException {
-        return LauncherMeta.getLauncherMeta().getVersion(gameVersion).getVersionMeta();
+    private VersionMeta.Download getServerDownload() throws IOException {
+        return getVersionMeta().downloads.get("server");
     }
 }

--- a/src/main/java/net/fabricmc/installer/server/ServerHandler.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerHandler.java
@@ -17,11 +17,10 @@
 package net.fabricmc.installer.server;
 
 import java.io.FileNotFoundException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.text.MessageFormat;
 
 import javax.swing.JPanel;
 
@@ -29,7 +28,6 @@ import net.fabricmc.installer.Handler;
 import net.fabricmc.installer.InstallerGui;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
-import net.fabricmc.installer.util.LauncherMeta;
 import net.fabricmc.installer.util.Utils;
 
 public class ServerHandler extends Handler {
@@ -71,6 +69,8 @@ public class ServerHandler extends Handler {
 			downloader.downloadMinecraftServer(serverJar);
 			InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.done"));
 		}
+
+		InstallerProgress.CONSOLE.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.done.start.server")).format(new Object[]{ServerInstaller.DEFAULT_LAUNCH_JAR_NAME}));
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/installer/server/ServerHandler.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerHandler.java
@@ -65,12 +65,10 @@ public class ServerHandler extends Handler {
 		ServerInstaller.install(dir, loaderVersion, gameVersion, InstallerProgress.CONSOLE);
 
 		if(args.has("downloadMinecraft")){
-			Path serverJar = dir.resolve("server.jar");
-			Path serverJarTmp = dir.resolve("server.jar.tmp");
-			Files.deleteIfExists(serverJar);
 			InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.download.minecraft"));
-			Utils.downloadFile(new URL(LauncherMeta.getLauncherMeta().getVersion(gameVersion).getVersionMeta().downloads.get("server").url), serverJarTmp);
-			Files.move(serverJarTmp, serverJar, StandardCopyOption.REPLACE_EXISTING);
+			Path serverJar = dir.resolve("server.jar");
+			MinecraftServerDownloader downloader = new MinecraftServerDownloader(gameVersion);
+			downloader.downloadMinecraftServer(serverJar);
 			InstallerProgress.CONSOLE.updateProgress(Utils.BUNDLE.getString("progress.done"));
 		}
 	}

--- a/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
@@ -54,8 +54,14 @@ import net.fabricmc.installer.util.Utils;
 public class ServerInstaller {
 	private static final String servicesDir = "META-INF/services/";
 	private static final String manifestPath = "META-INF/MANIFEST.MF";
+	private static final String DEFAULT_LAUNCH_JAR_NAME = "fabric-server-launch.jar";
 
 	public static void install(Path dir, String loaderVersion, String gameVersion, InstallerProgress progress) throws IOException {
+		Path launchJar = dir.resolve(DEFAULT_LAUNCH_JAR_NAME);
+		install(dir, loaderVersion, gameVersion, progress, launchJar);
+	}
+
+	public static void install(Path dir, String loaderVersion, String gameVersion, InstallerProgress progress, Path launchJar) throws IOException {
 		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.installing.server")).format(new Object[]{String.format("%s(%s)", loaderVersion, gameVersion)}));
 
 		Files.createDirectories(dir);
@@ -91,7 +97,6 @@ public class ServerInstaller {
 		final String DEFAULT_MAIN_CLASS_MANIFEST = "net.fabricmc.loader.launch.server.FabricServerLauncher";
 		mainClassManifest = (mainClassManifest == null) ? DEFAULT_MAIN_CLASS_MANIFEST : mainClassManifest;
 
-		Path launchJar = dir.resolve("fabric-server-launch.jar");
 		String mainClassMeta = json.at("mainClass").asString();
 		makeLaunchJar(launchJar, mainClassMeta, mainClassManifest, libraryFiles, progress);
 

--- a/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
@@ -54,7 +54,7 @@ import net.fabricmc.installer.util.Utils;
 public class ServerInstaller {
 	private static final String servicesDir = "META-INF/services/";
 	private static final String manifestPath = "META-INF/MANIFEST.MF";
-	private static final String DEFAULT_LAUNCH_JAR_NAME = "fabric-server-launch.jar";
+	public static final String DEFAULT_LAUNCH_JAR_NAME = "fabric-server-launch.jar";
 
 	public static void install(Path dir, String loaderVersion, String gameVersion, InstallerProgress progress) throws IOException {
 		Path launchJar = dir.resolve(DEFAULT_LAUNCH_JAR_NAME);
@@ -99,8 +99,6 @@ public class ServerInstaller {
 
 		String mainClassMeta = json.at("mainClass").asString();
 		makeLaunchJar(launchJar, mainClassMeta, mainClassManifest, libraryFiles, progress);
-
-		progress.updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.done.start.server")).format(new Object[]{launchJar.getFileName().toString()}));
 	}
 
 	private static void makeLaunchJar(Path file, String launchMainClass, String jarMainClass, List<Path> libraryFiles, InstallerProgress progress) throws IOException {

--- a/src/main/java/net/fabricmc/installer/util/LauncherMeta.java
+++ b/src/main/java/net/fabricmc/installer/util/LauncherMeta.java
@@ -20,6 +20,7 @@ import mjson.Json;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,7 +36,15 @@ public class LauncherMeta {
 	}
 
 	private static LauncherMeta load() throws IOException {
-		URL url = new URL("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json");
+		List<Version> versions = new ArrayList<>();
+		versions.addAll(getVersionsFromUrl(Reference.minecraftLauncherManifest));
+		versions.addAll(getVersionsFromUrl(Reference.experimentalVersionsManifest));
+
+		return new LauncherMeta(versions);
+	}
+
+	private static List<Version> getVersionsFromUrl(String urlStr) throws IOException {
+		URL url = new URL(urlStr);
 
 		String str = Utils.readTextFile(url);
 		Json json = Json.read(str);
@@ -45,7 +54,7 @@ public class LauncherMeta {
 				.map(Version::new)
 				.collect(Collectors.toList());
 
-		return new LauncherMeta(versions);
+		return versions;
 	}
 
 	public final List<Version> versions;

--- a/src/main/java/net/fabricmc/installer/util/Reference.java
+++ b/src/main/java/net/fabricmc/installer/util/Reference.java
@@ -21,6 +21,8 @@ public class Reference {
 
 	public static String metaServerUrl = "https://meta.fabricmc.net/";
 	public static String fabricApiUrl = "https://www.curseforge.com/minecraft/mc-mods/fabric-api/";
+	public static String minecraftLauncherManifest = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
+	public static String experimentalVersionsManifest = "https://maven.fabricmc.net/net/minecraft/experimental_versions.json";
 
 	public static String getMetaServerEndpoint(String path) {
 		return metaServerUrl + path;

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -121,4 +123,33 @@ public class Utils {
 		return "TNT"; // Fallback to TNT icon if we cant load Fabric icon.
 	}
 
+	public static String sha1String(Path path) throws IOException {
+		return bytesToHex(sha1(path));
+	}
+
+	public static byte[] sha1(Path path) throws IOException  {
+		MessageDigest digest = sha1Digest();
+		digest.update(Files.readAllBytes(path));
+		return digest.digest();
+	}
+
+	private static MessageDigest sha1Digest() {
+		try {
+			return MessageDigest.getInstance("SHA-1");
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("Something has gone really wrong", e);
+		}
+	}
+
+	// Thanks https://stackoverflow.com/a/9855338
+	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+	public static String bytesToHex(byte[] bytes) {
+		char[] hexChars = new char[bytes.length * 2];
+		for (int j = 0; j < bytes.length; j++) {
+			int v = bytes[j] & 0xFF;
+			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		}
+		return new String(hexChars);
+	}
 }

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -129,7 +129,16 @@ public class Utils {
 
 	public static byte[] sha1(Path path) throws IOException  {
 		MessageDigest digest = sha1Digest();
-		digest.update(Files.readAllBytes(path));
+
+		try (InputStream is = Files.newInputStream(path)) {
+			byte[] buffer = new byte[64*1024];
+			int len;
+
+			while ((len = is.read(buffer)) >= 0) {
+				digest.update(buffer, 0, len);
+			}
+		}
+
 		return digest.digest();
 	}
 
@@ -141,15 +150,13 @@ public class Utils {
 		}
 	}
 
-	// Thanks https://stackoverflow.com/a/9855338
-	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 	public static String bytesToHex(byte[] bytes) {
-		char[] hexChars = new char[bytes.length * 2];
-		for (int j = 0; j < bytes.length; j++) {
-			int v = bytes[j] & 0xFF;
-			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		StringBuilder output = new StringBuilder();
+
+		for (byte b : bytes) {
+			output.append(String.format("%02x", b));
 		}
-		return new String(hexChars);
+
+		return output.toString();
 	}
 }


### PR DESCRIPTION
This PR builds a new unateended installer jar that will be downloaded containing a `install.properties` file containg the game version and the loader version like so:

```
fabric-loader-version=0.11.6
game-version=1.17.1
```

These jar files will either generated on demand by meta and when ran with `java -jar` will download and setup the server without requiring any user interaction. This will remove the need for server owners to use the server GUI or battle with the args. A website providing direct downloads and download links will be provided to make it as easy as possible.

This will only work on loader 0.12 due to jimfs being required on the launchclasspath and a small change that allows skipping over the old logic for finding the server game jar.