### PR TITLE
Add option to select a custom loader jar, strip library signatures for server launcher jar

### DIFF
--- a/src/main/java/net/fabricmc/installer/LoaderVersion.java
+++ b/src/main/java/net/fabricmc/installer/LoaderVersion.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.installer;
+
+import java.nio.file.Path;
+
+public final class LoaderVersion {
+	public final String name;
+	public final Path path;
+
+	public LoaderVersion(String name) {
+		this.name = name;
+		this.path = null;
+	}
+
+	public LoaderVersion(String name, Path path) {
+		this.name = name;
+		this.path = path;
+	}
+}

--- a/src/main/java/net/fabricmc/installer/ServerLauncher.java
+++ b/src/main/java/net/fabricmc/installer/ServerLauncher.java
@@ -67,7 +67,7 @@ public final class ServerLauncher {
 	private static LaunchData initialise() throws IOException {
 		Properties properties = readProperties();
 
-		String loaderVersion = Objects.requireNonNull(properties.getProperty("fabric-loader-version"), "no loader-version specified in " + INSTALL_CONFIG_NAME);
+		LoaderVersion loaderVersion = new LoaderVersion(Objects.requireNonNull(properties.getProperty("fabric-loader-version"), "no loader-version specified in " + INSTALL_CONFIG_NAME));
 		String gameVersion = Objects.requireNonNull(properties.getProperty("game-version"), "no game-version specified in " + INSTALL_CONFIG_NAME);
 
 		// 0.12 or higher is required
@@ -76,7 +76,7 @@ public final class ServerLauncher {
 		// Vanilla server jar
 		Path serverJar = SERVER_DIR.resolve(String.format("%s-server.jar", gameVersion));
 		// Includes the mc version as this jar contains intermediary
-		Path serverLaunchJar = SERVER_DIR.resolve(String.format("fabric-loader-server-%s-minecraft-%s.jar", loaderVersion, gameVersion));
+		Path serverLaunchJar = SERVER_DIR.resolve(String.format("fabric-loader-server-%s-minecraft-%s.jar", loaderVersion.name, gameVersion));
 
 		if (Files.exists(serverJar) && Files.exists(serverLaunchJar)) {
 			try {
@@ -133,8 +133,8 @@ public final class ServerLauncher {
 		}
 	}
 
-	private static void validateLoaderVersion(String loaderVersion) {
-		String[] versionSplit = loaderVersion.split("\\.");
+	private static void validateLoaderVersion(LoaderVersion loaderVersion) {
+		String[] versionSplit = loaderVersion.name.split("\\.");
 
 		// future 1.x versions
 		if (Integer.parseInt(versionSplit[0]) > 0) {

--- a/src/main/java/net/fabricmc/installer/client/ClientHandler.java
+++ b/src/main/java/net/fabricmc/installer/client/ClientHandler.java
@@ -32,6 +32,7 @@ import javax.swing.event.HyperlinkEvent;
 
 import net.fabricmc.installer.Handler;
 import net.fabricmc.installer.InstallerGui;
+import net.fabricmc.installer.LoaderVersion;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
 import net.fabricmc.installer.util.Reference;
@@ -48,12 +49,14 @@ public class ClientHandler extends Handler {
 	@Override
 	public void install() {
 		String gameVersion = (String) gameVersionComboBox.getSelectedItem();
-		String loaderVersion = (String) loaderVersionComboBox.getSelectedItem();
+		LoaderVersion loaderVersion = queryLoaderVersion();
+		if (loaderVersion == null) return;
+
 		System.out.println("Installing");
 
 		new Thread(() -> {
 			try {
-				updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.installing")).format(new Object[]{loaderVersion}));
+				updateProgress(new MessageFormat(Utils.BUNDLE.getString("progress.installing")).format(new Object[]{loaderVersion.name}));
 				Path mcPath = Paths.get(installLocation.getText());
 
 				if (!Files.exists(mcPath)) {
@@ -66,7 +69,7 @@ public class ClientHandler extends Handler {
 					ProfileInstaller.setupProfile(mcPath, profileName, gameVersion);
 				}
 
-				SwingUtilities.invokeLater(() -> showInstalledMessage(loaderVersion, gameVersion));
+				SwingUtilities.invokeLater(() -> showInstalledMessage(loaderVersion.name, gameVersion));
 			} catch (Exception e) {
 				error(e);
 			}
@@ -105,7 +108,7 @@ public class ClientHandler extends Handler {
 		}
 
 		String gameVersion = getGameVersion(args);
-		String loaderVersion = getLoaderVersion(args);
+		LoaderVersion loaderVersion = new LoaderVersion(getLoaderVersion(args));
 
 		String profileName = ClientInstaller.install(path, gameVersion, loaderVersion, InstallerProgress.CONSOLE);
 

--- a/src/main/java/net/fabricmc/installer/client/ClientInstaller.java
+++ b/src/main/java/net/fabricmc/installer/client/ClientInstaller.java
@@ -21,15 +21,16 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import net.fabricmc.installer.LoaderVersion;
 import net.fabricmc.installer.util.InstallerProgress;
 import net.fabricmc.installer.util.Reference;
 import net.fabricmc.installer.util.Utils;
 
 public class ClientInstaller {
-	public static String install(Path mcDir, String gameVersion, String loaderVersion, InstallerProgress progress) throws IOException {
-		System.out.println("Installing " + gameVersion + " with fabric " + loaderVersion);
+	public static String install(Path mcDir, String gameVersion, LoaderVersion loaderVersion, InstallerProgress progress) throws IOException {
+		System.out.println("Installing " + gameVersion + " with fabric " + loaderVersion.name);
 
-		String profileName = String.format("%s-%s-%s", Reference.LOADER_NAME, loaderVersion, gameVersion);
+		String profileName = String.format("%s-%s-%s", Reference.LOADER_NAME, loaderVersion.name, gameVersion);
 
 		Path versionsDir = mcDir.resolve("versions");
 		Path profileDir = versionsDir.resolve(profileName);
@@ -51,7 +52,7 @@ public class ClientInstaller {
 		Files.deleteIfExists(dummyJar);
 		Files.createFile(dummyJar);
 
-		URL profileUrl = new URL(Reference.getMetaServerEndpoint(String.format("v2/versions/loader/%s/%s/profile/json", gameVersion, loaderVersion)));
+		URL profileUrl = new URL(Reference.getMetaServerEndpoint(String.format("v2/versions/loader/%s/%s/profile/json", gameVersion, loaderVersion.name)));
 		Utils.downloadFile(profileUrl, profileJson);
 
 		progress.updateProgress(Utils.BUNDLE.getString("progress.done"));

--- a/src/main/java/net/fabricmc/installer/server/ServerHandler.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerHandler.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 
 import net.fabricmc.installer.Handler;
 import net.fabricmc.installer.InstallerGui;
+import net.fabricmc.installer.LoaderVersion;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
 import net.fabricmc.installer.util.Utils;
@@ -39,7 +40,9 @@ public class ServerHandler extends Handler {
 	@Override
 	public void install() {
 		String gameVersion = (String) gameVersionComboBox.getSelectedItem();
-		String loaderVersion = (String) loaderVersionComboBox.getSelectedItem();
+		LoaderVersion loaderVersion = queryLoaderVersion();
+		if (loaderVersion == null) return;
+
 		new Thread(() -> {
 			try {
 				ServerInstaller.install(Paths.get(installLocation.getText()).toAbsolutePath(), loaderVersion, gameVersion, this);
@@ -60,7 +63,7 @@ public class ServerHandler extends Handler {
 			throw new FileNotFoundException("Server directory not found at " + dir + " or not a directory");
 		}
 
-		String loaderVersion = getLoaderVersion(args);
+		LoaderVersion loaderVersion = new LoaderVersion(getLoaderVersion(args));
 		String gameVersion = getGameVersion(args);
 		ServerInstaller.install(dir, loaderVersion, gameVersion, InstallerProgress.CONSOLE);
 

--- a/src/main/java/net/fabricmc/installer/util/Library.java
+++ b/src/main/java/net/fabricmc/installer/util/Library.java
@@ -17,16 +17,25 @@
 package net.fabricmc.installer.util;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import mjson.Json;
 
 public class Library {
 	public final String name;
 	public final String url;
+	public final Path inputPath;
+
+	public Library(String name, String url, Path inputPath) {
+		this.name = name;
+		this.url = url;
+		this.inputPath = inputPath;
+	}
 
 	public Library(Json json) {
 		name = json.at("name").asString();
 		url = json.at("url").asString();
+		inputPath = null;
 	}
 
 	public String getURL() {

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -92,6 +92,26 @@ public class Utils {
 		return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 	}
 
+	public static String readString(InputStream is) throws IOException {
+		byte[] data = new byte[Math.max(1000, is.available())];
+		int offset = 0;
+		int len;
+
+		while ((len = is.read(data, offset, data.length - offset)) >= 0) {
+			offset += len;
+
+			if (offset == data.length) {
+				int next = is.read();
+				if (next < 0) break;
+
+				data = Arrays.copyOf(data, data.length * 2);
+				data[offset++] = (byte) next;
+			}
+		}
+
+		return new String(data, 0, offset, StandardCharsets.UTF_8);
+	}
+
 	public static void writeToFile(Path path, String string) throws IOException {
 		Files.write(path, string.getBytes(StandardCharsets.UTF_8));
 	}


### PR DESCRIPTION
This adds a `(custom version)` entry at the bottom of the loader version list, which will ask the user to provide a loader jar instead of grabbing one from Meta. It'll extract the necessary information to build the server launcher from it instead of asking Meta.

The PR also fixes an instance of copying signature from libraries (access widener), which otherwise prevents the jar from executing.