### PR TITLE
Allow translating the vanilla server "Downloading" message

### DIFF
--- a/src/main/java/net/fabricmc/installer/server/ServerPostInstallDialog.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerPostInstallDialog.java
@@ -201,7 +201,7 @@ public class ServerPostInstallDialog extends JDialog {
 				while ((len = inputStream.read(buffer, 0, 1024)) >= 0) {
 					downloaded += len;
 
-					final String labelText = String.format("Downloading %d/%d MB", downloaded / MB, finalSize / MB);
+					final String labelText = new MessageFormat(Utils.BUNDLE.getString("prompt.server.downloading")).format(new Object[] {downloaded / MB, finalSize / MB});
 					SwingUtilities.invokeLater(() -> color(serverJarLabel, Color.BLUE).setText(labelText));
 
 					bufferedOutputStream.write(buffer, 0, len);

--- a/src/main/resources/lang/installer.properties
+++ b/src/main/resources/lang/installer.properties
@@ -30,6 +30,7 @@ prompt.server.info.scipt=Or generate launch scripts
 prompt.server.jar=Download server jar
 prompt.server.jar.valid=Valid {0} server jar found
 prompt.server.jar.invalid=No valid {0} server jar found
+prompt.server.downloading=Downloading {0}/{1} MB
 prompt.server.generate=Generate
 prompt.server.overwrite=Are you sure you want to override the existing launch scripts?
 prompt.install.successful.title=Successfully Installed


### PR DESCRIPTION
Found it wasn't translatable when testing my spanish translation. I'll try to update that PR if this gets accepted, but just in case I have no time the message would be `Descargando {0}/{1} MB`.