### PR TITLE
Add support for installing a Fabric server without shading the libs into the launcher jar

### DIFF
--- a/src/main/java/net/fabricmc/installer/Handler.java
+++ b/src/main/java/net/fabricmc/installer/Handler.java
@@ -21,14 +21,10 @@ import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.function.Consumer;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -42,8 +38,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileNameExtensionFilter;
-
-import mjson.Json;
 
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
@@ -191,19 +185,8 @@ public abstract class Handler implements InstallerProgress {
 
 			// determine loader version from fabric.mod.json
 
-			try (ZipFile zf = new ZipFile(file)) {
-				ZipEntry entry = zf.getEntry("fabric.mod.json");
-				if (entry == null) throw new FileNotFoundException("fabric.mod.json");
-
-				String modJsonContent;
-
-				try (InputStream is = zf.getInputStream(entry)) {
-					modJsonContent = Utils.readString(is);
-				}
-
-				String version = Json.read(modJsonContent).at("version").asString();
-
-				return new LoaderVersion(version, file.toPath());
+			try {
+				return new LoaderVersion(file.toPath());
 			} catch (IOException e) {
 				error(e);
 				return null;

--- a/src/main/java/net/fabricmc/installer/server/ServerPostInstallDialog.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerPostInstallDialog.java
@@ -62,15 +62,16 @@ import net.fabricmc.installer.util.LauncherMeta;
 import net.fabricmc.installer.util.Utils;
 
 public class ServerPostInstallDialog extends JDialog {
+	private static final String launchCommand = "java -Xmx2G -jar fabric-server-launch.jar nogui";
 	private static final int MB = 1000000;
 
-	private JPanel panel = new JPanel();
+	private final JPanel panel = new JPanel();
 
-	private ServerHandler serverHandler;
-	private String minecraftVersion;
-	private Path installDir;
-	private Path minecraftJar;
-	private Path minecraftJarTmp;
+	private final ServerHandler serverHandler;
+	private final String minecraftVersion;
+	private final Path installDir;
+	private final Path minecraftJar;
+	private final Path minecraftJarTmp;
 
 	private JLabel serverJarLabel;
 	private JButton downloadButton;
@@ -105,7 +106,7 @@ public class ServerPostInstallDialog extends JDialog {
 
 		addRow(panel, panel -> panel.add(fontSize(new JLabel(Utils.BUNDLE.getString("prompt.server.info.command")), 15)));
 		addRow(panel, panel -> {
-			JTextField textField = new JTextField("java -jar fabric-server-launch.jar");
+			JTextField textField = new JTextField(launchCommand);
 			textField.setHorizontalAlignment(JTextField.CENTER);
 			panel.add(textField);
 		});
@@ -222,8 +223,6 @@ public class ServerPostInstallDialog extends JDialog {
 	}
 
 	private void generateLaunchScripts() {
-		String launchCommand = "java -jar fabric-server-launch.jar";
-
 		Map<Path, String> launchScripts = new HashMap<>();
 		launchScripts.put(installDir.resolve("start.bat"), launchCommand + "\npause");
 		launchScripts.put(installDir.resolve("start.sh"), "#!/usr/bin/env bash\n" + launchCommand);


### PR DESCRIPTION
This
- moves the library downloads to the libraries folder (similar to MC's bundler)
- replaces fabric-server-launch.jar shading with the Class-Path manifest entry referencing the libs (Loader 0.12.6+ only)
- removes failed partial downloads
- replaces the command line used in the start script and shown in the gui with one that isn't complete garbage