### PR TITLE
Create profiles entry if it is missing

### DIFF
--- a/src/main/java/net/fabricmc/installer/client/ProfileInstaller.java
+++ b/src/main/java/net/fabricmc/installer/client/ProfileInstaller.java
@@ -55,18 +55,22 @@ public class ProfileInstaller {
 		Json jsonObject = Json.read(Utils.readString(launcherProfiles));
 
 		Json profiles = jsonObject.at("profiles");
+
+		if (profiles == null) {
+			profiles = Json.object();
+			jsonObject.set("profiles", profiles);
+		}
+
 		String profileName = Reference.LOADER_NAME + "-" + gameVersion;
 
-		Json profile;
+		Json profile = profiles.at(profileName);
 
-		if (profiles.has(profileName)) {
-			profile = profiles.at(profileName);
-		} else {
+		if (profile == null) {
 			profile = createProfile(profileName);
+			profiles.set(profileName, profile);
 		}
 
 		profile.set("lastVersionId", name);
-		profiles.set(profileName, profile);
 
 		Utils.writeToFile(launcherProfiles, jsonObject.toString());
 	}


### PR DESCRIPTION
I've seen a few support inquiries where the `"profiles":{..}` entry in the launcher profiles json is absent. This PR creates it instead of throwing NPE at the first access to `profiles`.