### PR TITLE
Use Windows cert store.

### DIFF
--- a/src/main/java/net/fabricmc/installer/Main.java
+++ b/src/main/java/net/fabricmc/installer/Main.java
@@ -20,13 +20,13 @@ import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import net.fabricmc.installer.client.ClientHandler;
 import net.fabricmc.installer.server.ServerHandler;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.CrashDialog;
 import net.fabricmc.installer.util.MetaHandler;
+import net.fabricmc.installer.util.OperatingSystem;
 import net.fabricmc.installer.util.Reference;
 
 public class Main {
@@ -36,13 +36,9 @@ public class Main {
 	public static final List<Handler> HANDLERS = new ArrayList<>();
 
 	public static void main(String[] args) throws IOException {
-		String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-
-		// Use the operating system cert store
-		if (osName.contains("win")) {
+		if (OperatingSystem.CURRENT == OperatingSystem.WINDOWS) {
+			// Use the operating system cert store
 			System.setProperty("javax.net.ssl.trustStoreType", "WINDOWS-ROOT");
-		} else if (osName.contains("mac")) {
-			System.setProperty("javax.net.ssl.trustStoreType", "KeychainStore");
 		}
 
 		System.out.println("Loading Fabric Installer: " + Main.class.getPackage().getImplementationVersion());

--- a/src/main/java/net/fabricmc/installer/Main.java
+++ b/src/main/java/net/fabricmc/installer/Main.java
@@ -20,6 +20,7 @@ import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import net.fabricmc.installer.client.ClientHandler;
 import net.fabricmc.installer.server.ServerHandler;
@@ -35,6 +36,15 @@ public class Main {
 	public static final List<Handler> HANDLERS = new ArrayList<>();
 
 	public static void main(String[] args) throws IOException {
+		String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+
+		// Use the operating system cert store
+		if (osName.contains("win")) {
+			System.setProperty("javax.net.ssl.trustStoreType", "WINDOWS-ROOT");
+		} else if (osName.contains("mac")) {
+			System.setProperty("javax.net.ssl.trustStoreType", "KeychainStore");
+		}
+
 		System.out.println("Loading Fabric Installer: " + Main.class.getPackage().getImplementationVersion());
 
 		HANDLERS.add(new ClientHandler());

--- a/src/main/java/net/fabricmc/installer/launcher/NativesHelper.java
+++ b/src/main/java/net/fabricmc/installer/launcher/NativesHelper.java
@@ -26,8 +26,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import net.fabricmc.installer.util.OperatingSystem;
+
 public class NativesHelper {
-	private static final String OS_ID = getOS() + "-" + System.getProperty("os.arch").toLowerCase(Locale.ROOT);
+	private static final String OS_ID = OperatingSystem.CURRENT.name().toLowerCase(Locale.ROOT) + "-" + System.getProperty("os.arch").toLowerCase(Locale.ROOT);
 	private static final Map<String, String> NATIVES_MAP = getNativesMap();
 
 	private static boolean loaded = false;
@@ -47,18 +49,6 @@ public class NativesHelper {
 		natives.put("macos-aarch64", "natives/macos-x86_64_arm64.dylib");
 
 		return natives;
-	}
-
-	private static String getOS() {
-		String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-
-		if (osName.contains("win")) {
-			return "windows";
-		} else if (osName.contains("mac")) {
-			return "macos";
-		} else {
-			return "linux";
-		}
 	}
 
 	public static boolean loadSafelyIfCompatible() {

--- a/src/main/java/net/fabricmc/installer/util/OperatingSystem.java
+++ b/src/main/java/net/fabricmc/installer/util/OperatingSystem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.installer.util;
+
+public enum OperatingSystem {
+	WINDOWS,
+	MACOS,
+	LINUX;
+
+	public static final OperatingSystem CURRENT = getCurrent();
+
+	private static OperatingSystem getCurrent() {
+		String osName = System.getProperty("os.name").toLowerCase();
+
+		if (osName.contains("win")) {
+			return WINDOWS;
+		} else if (osName.contains("mac")) {
+			return MACOS;
+		} else {
+			return LINUX;
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/installer/util/OperatingSystem.java
+++ b/src/main/java/net/fabricmc/installer/util/OperatingSystem.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.installer.util;
 
+import java.util.Locale;
+
 public enum OperatingSystem {
 	WINDOWS,
 	MACOS,
@@ -24,7 +26,7 @@ public enum OperatingSystem {
 	public static final OperatingSystem CURRENT = getCurrent();
 
 	private static OperatingSystem getCurrent() {
-		String osName = System.getProperty("os.name").toLowerCase();
+		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 
 		if (osName.contains("win")) {
 			return WINDOWS;

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -61,16 +61,15 @@ public class Utils {
 	});
 
 	public static Path findDefaultInstallDir() {
-		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 		Path dir;
 
-		if (os.contains("win") && System.getenv("APPDATA") != null) {
+		if (OperatingSystem.CURRENT == OperatingSystem.WINDOWS && System.getenv("APPDATA") != null) {
 			dir = Paths.get(System.getenv("APPDATA")).resolve(".minecraft");
 		} else {
 			String home = System.getProperty("user.home", ".");
 			Path homeDir = Paths.get(home);
 
-			if (os.contains("mac")) {
+			if (OperatingSystem.CURRENT == OperatingSystem.MACOS) {
 				dir = homeDir.resolve("Library").resolve("Application Support").resolve("minecraft");
 			} else {
 				dir = homeDir.resolve(".minecraft");


### PR DESCRIPTION
3rd party AVs and firewalls sometimes use their own root cert to allow SSL filterting, these products usually attempt to install their root cert into Java's own keychain, but due to the 101 diffrent locations that Java can be installed to it doesnt always work. (Especially for Java included with Minecraft)

This PR uses the system cert store on windows.
