### PR TITLE
Fix anti-aliasing on certain systems

### DIFF
--- a/src/main/java/net/fabricmc/installer/Main.java
+++ b/src/main/java/net/fabricmc/installer/Main.java
@@ -36,6 +36,7 @@ public class Main {
 	public static final List<Handler> HANDLERS = new ArrayList<>();
 
 	public static void main(String[] args) throws IOException {
+		System.setProperty("awt.useSystemAAFontSettings","on");
 		if (OperatingSystem.CURRENT == OperatingSystem.WINDOWS) {
 			// Use the operating system cert store
 			System.setProperty("javax.net.ssl.trustStoreType", "WINDOWS-ROOT");


### PR DESCRIPTION
This makes the font actually anti-aliased on my system (Linux, KDE on Xorg).

I can't test the effect of this on other systems right now, so I would appreciate if someone on Windows/MacOS/Linux Wayland could test this and make sure it doesn't break anything on those systems.

Before:
![Before](https://github.com/FabricMC/fabric-installer/assets/5115825/c32bbf22-bd0a-498d-9d36-f3889c23d0de)


After:
![After](https://github.com/FabricMC/fabric-installer/assets/5115825/bda3a2ee-7ac9-47dc-8111-618bfe5967d1)
