### PR TITLE
CLI: reject invalid game/loader versions, support latest as a value

### DIFF
--- a/src/main/java/net/fabricmc/installer/Handler.java
+++ b/src/main/java/net/fabricmc/installer/Handler.java
@@ -48,6 +48,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.InstallerProgress;
 import net.fabricmc.installer.util.MetaHandler;
+import net.fabricmc.installer.util.MetaHandler.GameVersion;
 import net.fabricmc.installer.util.Utils;
 
 public abstract class Handler implements InstallerProgress {
@@ -289,18 +290,17 @@ public abstract class Handler implements InstallerProgress {
 	}
 
 	protected String getGameVersion(ArgumentParser args) {
-		return args.getOrDefault("mcversion", () -> {
-			System.out.println("Using latest game version");
-
-			return Main.GAME_VERSION_META.getLatestVersion(args.has("snapshot")).getVersion();
-		});
+		return getVersion(args.get("mcversion"), args.has("snapshot"), Main.GAME_VERSION_META);
 	}
 
 	protected String getLoaderVersion(ArgumentParser args) {
-		return args.getOrDefault("loader", () -> {
-			System.out.println("Using latest loader version");
+		return getVersion(args.get("loader"), false, Main.LOADER_META);
+	}
 
-			return Main.LOADER_META.getLatestVersion(false).getVersion();
-		});
+	private static String getVersion(String name, boolean snapshot, MetaHandler meta) {
+		GameVersion ret = meta.parseVersion(name, snapshot);
+		if (ret == null) throw new IllegalArgumentException(String.format("unknown %s version: %s", meta.getName(), name));
+
+		return ret.getVersion();
 	}
 }

--- a/src/main/java/net/fabricmc/installer/Main.java
+++ b/src/main/java/net/fabricmc/installer/Main.java
@@ -57,8 +57,8 @@ public class Main {
 			FabricService.setFixed(metaUrl, mavenUrl);
 		}
 
-		GAME_VERSION_META = new MetaHandler("v2/versions/game");
-		LOADER_META = new MetaHandler("v2/versions/loader");
+		GAME_VERSION_META = new MetaHandler("game", "v2/versions/game");
+		LOADER_META = new MetaHandler("loader", "v2/versions/loader");
 
 		//Default to the help command in a headless environment
 		if (GraphicsEnvironment.isHeadless() && command == null) {

--- a/src/main/java/net/fabricmc/installer/util/MetaHandler.java
+++ b/src/main/java/net/fabricmc/installer/util/MetaHandler.java
@@ -24,11 +24,17 @@ import java.util.stream.Collectors;
 import mjson.Json;
 
 public class MetaHandler extends CompletableHandler<List<MetaHandler.GameVersion>> {
+	private final String name;
 	private final String metaPath;
 	private List<GameVersion> versions;
 
-	public MetaHandler(String path) {
+	public MetaHandler(String name, String path) {
+		this.name = name;
 		this.metaPath = path;
+	}
+
+	public String getName() {
+		return name;
 	}
 
 	public void load() throws IOException {
@@ -60,9 +66,23 @@ public class MetaHandler extends CompletableHandler<List<MetaHandler.GameVersion
 		return versions.get(0);
 	}
 
-	public static class GameVersion {
-		String version;
-		boolean stable;
+	public GameVersion parseVersion(String value, boolean snapshot) {
+		if (value == null || value.isEmpty() || value.equalsIgnoreCase("latest")) {
+			return getLatestVersion(snapshot);
+		} else {
+			for (GameVersion version : versions) {
+				if (version.version.equals(value)) {
+					return version;
+				}
+			}
+
+			return null;
+		}
+	}
+
+	public static final class GameVersion {
+		final String version;
+		final boolean stable;
 
 		public GameVersion(Json json) {
 			version = json.at("version").asString();


### PR DESCRIPTION
Before this change we had two issues:
- Supplying an invalid version to the installer cli args ends up failing with an unhelpful HTTP 400 error from meta (`https://meta.fabricmc.net/v2/versions/loader/1.20.1/invalidHere/server/json`), shown as an exception to the user
-  Using `latest` as somewhat suggested by the cli help treats the string literally, which for meta is an invalid version

This commit verifies the supplied game and loader versions prior to any processing, throwing a more appropriate exception. It also handles `latest` as expected.